### PR TITLE
docs(license): set project copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,9 @@
+Copyright 2026 HsienW.
+
+All rights not expressly granted under the Apache License, Version 2.0,
+are reserved by the copyright holder. This Work is made available subject
+to the following license terms and conditions.
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -186,7 +192,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 HsienW
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Keep the Apache 2.0 license text paired with the project-specific copyright holder.

- Add the HsienW 2026 copyright notice

- Preserve reserved-rights guidance before the standard license terms