### PR TITLE
fix(backend): preserve async iterable stream contracts

### DIFF
--- a/backend/src/platform/interaction-runtime.test.ts
+++ b/backend/src/platform/interaction-runtime.test.ts
@@ -12,6 +12,35 @@ import {
   type InteractionOrchestratorConfig,
 } from "./interaction-runtime.js";
 
+const STREAM_METHOD_NAMES = ["stream", "streamEvents", "streamLog"] as const;
+
+function createTestStream(chunk: unknown): AsyncIterable<unknown> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield chunk;
+    },
+  };
+}
+
+function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      Symbol.asyncIterator in value &&
+      typeof value[Symbol.asyncIterator] === "function"
+  );
+}
+
+async function consumeTestStream(value: unknown): Promise<unknown[]> {
+  if (!isAsyncIterable(value)) {
+    throw new TypeError("Expected an AsyncIterable test stream");
+  }
+
+  const chunks: unknown[] = [];
+  for await (const chunk of value) chunks.push(chunk);
+  return chunks;
+}
+
 const configuredPolicy = (strategy: "reject" | "enqueue" | "supersede") =>
   JSON.stringify({
     strategy,
@@ -99,6 +128,40 @@ function configuredDependencies(strategy: "reject" | "enqueue" | "supersede") {
 }
 
 describe("interaction runtime production wrapper", () => {
+  it.each(STREAM_METHOD_NAMES)(
+    "returns %s as an AsyncIterable before asynchronous setup starts",
+    async (streamMethodName) => {
+      const orchestrator: InteractionOrchestrator = {
+        isConfigured: true,
+        beforeRun: vi.fn(async () => ({ configured: true, events: [] })),
+        afterRun: vi.fn(async () => undefined),
+      };
+      const graph = {
+        stream: vi.fn((_input?: unknown, _config?: unknown) =>
+          createTestStream("stream")
+        ),
+        streamEvents: vi.fn((_input?: unknown, _config?: unknown) =>
+          createTestStream("streamEvents")
+        ),
+        streamLog: vi.fn((_input?: unknown, _config?: unknown) =>
+          createTestStream("streamLog")
+        ),
+      };
+      const governed = applyInteractionGovernance(graph, orchestrator);
+
+      const stream = governed[streamMethodName]({}, runConfig());
+
+      expect(stream).not.toBeInstanceOf(Promise);
+      expect(orchestrator.beforeRun).not.toHaveBeenCalled();
+
+      const chunks: unknown[] = [];
+      for await (const chunk of stream) chunks.push(chunk);
+
+      expect(chunks).toEqual([streamMethodName]);
+      expect(orchestrator.afterRun).toHaveBeenCalledOnce();
+    }
+  );
+
   it("is a true no-op when no InteractionPolicy is configured", async () => {
     let markFirstStarted: (() => void) | undefined;
     let releaseFirst: (() => void) | undefined;
@@ -314,18 +377,19 @@ describe("interaction runtime production wrapper", () => {
   it("marks ownership terminal when stream setup fails", async () => {
     const dependencies = configuredDependencies("supersede");
     const graph = {
-      stream: vi.fn(async (_input: unknown, _config?: unknown) => {
-        throw new Error("stream setup failed");
-      }),
+      stream: vi.fn(
+        (_input: unknown, _config?: unknown): unknown =>
+          Promise.reject(new Error("stream setup failed"))
+      ),
     };
     const governed = applyInteractionGovernance(
       graph,
       createInteractionOrchestrator(dependencies.config)
     );
 
-    await expect(governed.stream({}, runConfig())).rejects.toThrow(
-      "stream setup failed"
-    );
+    await expect(
+      consumeTestStream(governed.stream({}, runConfig()))
+    ).rejects.toThrow("stream setup failed");
     expect(dependencies.ownershipRepository.markTerminal).toHaveBeenCalledWith({
       threadId: "thread-1",
       scopeId: "scope-1",

--- a/backend/src/platform/interaction-runtime.ts
+++ b/backend/src/platform/interaction-runtime.ts
@@ -618,33 +618,49 @@ async function invokeGraphMethod(
 }
 
 function createGovernedStream(
-  source: AsyncIterable<unknown>,
-  start: InteractionRunStart,
+  method: (...args: unknown[]) => unknown,
+  target: object,
+  input: unknown,
   config: unknown,
   orchestrator: InteractionOrchestrator
 ): AsyncIterable<unknown> {
-  return {
-    async *[Symbol.asyncIterator]() {
-      let completed = false;
-      let terminalStatus: "completed" | "cancelled" = "cancelled";
-      try {
-        for (const event of start.events) {
-          yield { interaction_runtime: { taskEvent: event } };
-        }
-        for await (const chunk of source) yield chunk;
-        completed = true;
-        terminalStatus = "completed";
-      } catch (error) {
-        terminalStatus = isCancelled(error, config) ? "cancelled" : "completed";
-        throw error;
-      } finally {
-        if (!completed && terminalStatus !== "completed") {
-          terminalStatus = "cancelled";
-        }
-        await orchestrator.afterRun(start, terminalStatus);
+  return (async function* generateGovernedStream() {
+    const start = await orchestrator.beforeRun(input, config);
+    let source: unknown;
+    try {
+      source = await invokeGraphMethod(method, target, input, config);
+      if (!isAsyncIterable(source)) {
+        throw new TypeError(
+          "Interaction-governed graph stream method did not return an AsyncIterable"
+        );
       }
-    },
-  };
+    } catch (error) {
+      await orchestrator.afterRun(
+        start,
+        isCancelled(error, config) ? "cancelled" : "completed"
+      );
+      throw error;
+    }
+
+    let completed = false;
+    let terminalStatus: "completed" | "cancelled" = "cancelled";
+    try {
+      for (const event of start.events) {
+        yield { interaction_runtime: { taskEvent: event } };
+      }
+      for await (const chunk of source) yield chunk;
+      completed = true;
+      terminalStatus = "completed";
+    } catch (error) {
+      terminalStatus = isCancelled(error, config) ? "cancelled" : "completed";
+      throw error;
+    } finally {
+      if (!completed && terminalStatus !== "completed") {
+        terminalStatus = "cancelled";
+      }
+      await orchestrator.afterRun(start, terminalStatus);
+    }
+  })();
 }
 
 export function applyInteractionGovernance<TGraph extends object>(
@@ -677,25 +693,8 @@ export function applyInteractionGovernance<TGraph extends object>(
       }
 
       if (STREAM_METHODS.has(property)) {
-        return async (input: unknown, config?: RunnableConfig) => {
-          const start = await orchestrator.beforeRun(input, config);
-          let source: unknown;
-          try {
-            source = await invokeGraphMethod(member, target, input, config);
-            if (!isAsyncIterable(source)) {
-              throw new TypeError(
-                "Interaction-governed graph stream method did not return an AsyncIterable"
-              );
-            }
-          } catch (error) {
-            await orchestrator.afterRun(
-              start,
-              isCancelled(error, config) ? "cancelled" : "completed"
-            );
-            throw error;
-          }
-          return createGovernedStream(source, start, config, orchestrator);
-        };
+        return (input: unknown, config?: RunnableConfig) =>
+          createGovernedStream(member, target, input, config, orchestrator);
       }
 
       return member.bind(target);

--- a/backend/src/platform/tracing/opik/opik-graph.test.ts
+++ b/backend/src/platform/tracing/opik/opik-graph.test.ts
@@ -10,6 +10,16 @@ import type {
 } from "./opik-tracer.js";
 import { instrumentGraphWithOpik, withOpikNode } from "./opik-graph.js";
 
+const STREAM_METHOD_NAMES = ["stream", "streamEvents", "streamLog"] as const;
+
+function createTestStream(chunk: unknown): AsyncIterable<unknown> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield chunk;
+    },
+  };
+}
+
 class RecordingTracer implements OpikTracer {
   readonly agentRunCalls: Array<{
     agentName: string;
@@ -83,6 +93,63 @@ class RecordingTracer implements OpikTracer {
 }
 
 describe("instrumentGraphWithOpik", () => {
+  it.each(STREAM_METHOD_NAMES)(
+    "returns %s as an AsyncIterable without awaiting the wrapper",
+    async (streamMethodName) => {
+      const tracer = new RecordingTracer();
+      const graph = {
+        stream: vi.fn((_input?: unknown, _config?: unknown) =>
+          createTestStream("stream")
+        ),
+        streamEvents: vi.fn((_input?: unknown, _config?: unknown) =>
+          createTestStream("streamEvents")
+        ),
+        streamLog: vi.fn((_input?: unknown, _config?: unknown) =>
+          createTestStream("streamLog")
+        ),
+      };
+      const instrumented = instrumentGraphWithOpik(graph, "weather", tracer);
+
+      const stream = instrumented[streamMethodName](
+        {},
+        { configurable: { thread_id: "thread-1", run_id: "run-1" } }
+      );
+
+      expect(stream).not.toBeInstanceOf(Promise);
+
+      const chunks: unknown[] = [];
+      for await (const chunk of stream) chunks.push(chunk);
+
+      expect(chunks).toEqual([streamMethodName]);
+      expect(tracer.agentStreamCalls).toEqual([
+        {
+          agentName: "weather",
+          metadata: { threadId: "thread-1", runId: "run-1" },
+        },
+      ]);
+    }
+  );
+
+  it("returns an AsyncIterable when correlation metadata is unavailable", async () => {
+    const tracer = new RecordingTracer();
+    const graph = {
+      streamEvents: vi.fn((_input?: unknown, _config?: unknown) =>
+        createTestStream("event")
+      ),
+    };
+    const instrumented = instrumentGraphWithOpik(graph, "weather", tracer);
+
+    const stream = instrumented.streamEvents({}, {});
+
+    expect(stream).not.toBeInstanceOf(Promise);
+
+    const chunks: unknown[] = [];
+    for await (const chunk of stream) chunks.push(chunk);
+
+    expect(chunks).toEqual(["event"]);
+    expect(tracer.agentStreamCalls).toEqual([]);
+  });
+
   it("preserves an existing node step identifier", async () => {
     const tracer = new RecordingTracer();
     const withNodeSpan = vi.spyOn(tracer, "withNodeSpan");

--- a/backend/src/platform/tracing/opik/opik-graph.ts
+++ b/backend/src/platform/tracing/opik/opik-graph.ts
@@ -84,6 +84,15 @@ async function invokeStreamMethod(
   return output;
 }
 
+function createDeferredStream(
+  streamFactory: () => Promise<AsyncIterable<unknown>>
+): AsyncIterable<unknown> {
+  return (async function* generateDeferredStream() {
+    const stream = await streamFactory();
+    for await (const chunk of stream) yield chunk;
+  })();
+}
+
 export function instrumentGraphWithOpik<TGraph extends object>(
   graph: TGraph,
   agentName: string,
@@ -105,12 +114,12 @@ export function instrumentGraphWithOpik<TGraph extends object>(
       }
 
       if (TRACED_STREAM_METHODS.has(property)) {
-        return async (input: unknown, config?: unknown) => {
+        return (input: unknown, config?: unknown) => {
           const metadata = readAgentRunMetadata(config);
           const execution = () => invokeStreamMethod(member, target, input, config);
           return metadata && !tracer.getActiveTraceId()
             ? tracer.traceAgentStream(agentName, metadata, execution)
-            : execution();
+            : createDeferredStream(execution);
         };
       }
 


### PR DESCRIPTION
- Defer interaction governance setup until stream consumption.

- Keep stream, streamEvents, and streamLog synchronous at the wrapper boundary.

- Preserve Opik tracing while returning AsyncIterable values directly.

- Cover traced, untraced, and stream setup failure behavior.